### PR TITLE
Fix lint failure.

### DIFF
--- a/src/colorUtils.js
+++ b/src/colorUtils.js
@@ -61,6 +61,7 @@ function closestColor(rgb) {
     if (closestDistanceSoFar < 1) {
       return closestColorFound;
     }
+    return undefined; // todo, return something better
   });
   return closestColorFound;
 }


### PR DESCRIPTION
Lint was complaining that closestColor was not returning anything
when both if' statements were false.

I worked around this by returning undefined.  But I am not
sure if this is a good idea.